### PR TITLE
Update Zigbee2MQTT to version 2.6.2 and upgrade dependencies

### DIFF
--- a/zigbee2mqtt/Dockerfile
+++ b/zigbee2mqtt/Dockerfile
@@ -1,18 +1,18 @@
 # Build stage
 # https://github.com/hassio-addons/addon-debian-base
 # Remember to update build file as well
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:8.1.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:8.1.4
 FROM ${BUILD_FROM} AS builder
 
 # Set Zigbee2MQTT Version. Needs to be after FROM
 # https://github.com/Koenkk/zigbee2mqtt/releases
-ARG ZIGBEE2MQTT_VERSION=2.6.1
+ARG ZIGBEE2MQTT_VERSION=2.6.2
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup Node.js 20 (LTS) and build dependencies
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
     nodejs \
@@ -41,14 +41,14 @@ RUN pnpm install --frozen-lockfile --no-optional \
 # Runtime stage
 # https://github.com/hassio-addons/addon-debian-base
 # Remember to update build file as well
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:8.1.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:8.1.4
 FROM ${BUILD_FROM}
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install only runtime dependencies
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
     nodejs \

--- a/zigbee2mqtt/build.yaml
+++ b/zigbee2mqtt/build.yaml
@@ -1,3 +1,3 @@
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base:8.1.1
-  amd64: ghcr.io/hassio-addons/debian-base:8.1.1
+  aarch64: ghcr.io/hassio-addons/debian-base:8.1.4
+  amd64: ghcr.io/hassio-addons/debian-base:8.1.4

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Zigbee2mqtt",
-  "version": "2.6.1-1",
+  "version": "2.6.2-1",
   "slug": "zigbee2mqtt",
   "description": "Zigbee2MQTT add-on by Scootec",
   "url": "https://github.com/scoootec/addon-zigbee2mqtt",


### PR DESCRIPTION
- Upgrade Zigbee2MQTT from 2.6.1 to 2.6.2
- Upgrade Debian base image from 8.1.1 to 8.1.4
- Upgrade Node.js from 20.x LTS to 22.x LTS
- Update add-on version to 2.6.2-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)